### PR TITLE
should be 4096

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -15,7 +15,7 @@ config SPIFFS_SIZE
 
 config SPIFFS_LOG_BLOCK_SIZE
     int "SPIFFS Logical block size"
-    range 4098 65536
+    range 4096 65536
     default 8192
 
 config SPIFFS_LOG_PAGE_SIZE


### PR DESCRIPTION
For some reason, withthe latest esp-idf the default blocksize of 8192 isn't working, it must be 4096. However the min default was incorrectly set to 4098 ;-)